### PR TITLE
added ReLU

### DIFF
--- a/neuroptica/nonlinearities.py
+++ b/neuroptica/nonlinearities.py
@@ -294,7 +294,7 @@ class LinearMask(ComplexNonlinearity):
         # return ((Z.T * self.mask) / Z.T).T
 
 
-class ReLU(ComplexNonlinearity):
+class bpReLU(ComplexNonlinearity):
     '''
     Discontinuous (but holomorphic and backpropable) ReLU
     f(x_i) = alpha * x_i   if |x_i| <   cutoff

--- a/tests/test_nonlinearities.py
+++ b/tests/test_nonlinearities.py
@@ -45,7 +45,7 @@ class TestNonlinearities(NeuropticaTest):
                               ElectroOpticActivation(N, **eo_settings),
                               SPMActivation(N, 1),
                               LinearMask(N, mask=np.random.rand(N)),
-                              ReLU(N, cutoff=0.5, alpha=0.1),
+                              bpReLU(N, cutoff=0.5, alpha=0.1),
                               modReLU(N, cutoff=0.5),
                               cReLU(N),
                               zReLU(N)]


### PR DESCRIPTION
I added a (discontinuous) ReLU activation of the form

      f(x_i) = alpha * x_i   if |x_i| <  cutoff
      f(x_i) = x_i                if |x_i| >= cutoff

This activation is nice because it has the property `f(z)/z = f'(z)`, which means the backprop step can be done by simply propagating the error signal through the same system as the forward prop activation.

I want to test whether this activation can be useful in real problems.

Added tests, which passed.