### PR TITLE
checks port_indeces and converts to lists

### DIFF
--- a/neuroptica/layers.py
+++ b/neuroptica/layers.py
@@ -31,10 +31,9 @@ class DropMask(NetworkLayer):
         if (keep_ports is not None and drop_ports is not None) or (keep_ports is None and drop_ports is None):
             raise ValueError("specify exactly one of keep_ports or drop_ports")
         if keep_ports:
-            print(keep_ports)
             if isinstance(keep_ports, range):
                 keep_ports = list(keep_ports)
-            elif isinstance(keep_ports, int) or isinstance(keep_ports, float):
+            elif isinstance(keep_ports, int):
                 keep_ports = [keep_ports]
             self.ports = keep_ports
         elif drop_ports:


### PR DESCRIPTION
DropMask Activation currently takes a list, would be convenient to also allow user to specify `int` or `range`.

This fix checks the input to see if its one of these types and, if so, converts to a `list`